### PR TITLE
refactor: use CSSOM API for CSP-compliant style application

### DIFF
--- a/projects/watermark/src/lib/utils.ts
+++ b/projects/watermark/src/lib/utils.ts
@@ -23,18 +23,23 @@ export function getDataSetKey(attributeName: string) {
     });
 }
 
-/** 将样式对象转换为字符串 */
-export const getStyleStr = (style: Record<string, string | number>) => {
-  let str = '';
+/** 通过 CSSOM API 应用样式（CSP 安全，无需 unsafe-inline） */
+export const applyStyle = (el: HTMLElement, style: Record<string, string | number>) => {
+  el.style.cssText = '';
 
   Object.keys(style).forEach(key => {
-    const k = key.replace(/([A-Z])/g, '-$1').toLowerCase();
     if (style[key] !== '' && style[key] != null) {
-      str += `${k}:${style[key]};`;
+      const value = String(style[key]);
+      const prop = key.replace(/([A-Z])/g, '-$1').toLowerCase();
+
+      if (value.endsWith('!important')) {
+        const cleanValue = value.replace(/\s*!important$/, '');
+        el.style.setProperty(prop, cleanValue, 'important');
+      } else {
+        el.style.setProperty(prop, value);
+      }
     }
   });
-
-  return str;
 };
 
 /** 创建随机 ID */
@@ -96,7 +101,7 @@ export const createHost = (watermarkTag: string) => {
     'transform': 'none !important',
     'clip-path': 'none !important',
   };
-  dom.setAttribute('style', getStyleStr(hiddenCSS));
+  applyStyle(dom, hiddenCSS);
   dom.setAttribute(attributeNameTag, watermarkTag);
   return dom;
 };

--- a/projects/watermark/src/lib/watermark.ts
+++ b/projects/watermark/src/lib/watermark.ts
@@ -1,5 +1,6 @@
 import { WatermarkOptions } from './types';
 import {
+  applyStyle,
   attributeNameTag,
   createHost,
   decrypt,
@@ -7,7 +8,6 @@ import {
   getDataSetKey,
   getDrawPattern,
   getRandomId,
-  getStyleStr,
   observeOptions,
 } from './utils';
 
@@ -74,14 +74,14 @@ export class Watermark {
   show() {
     if (this.watermarkDom) {
       this.style['display'] = 'block';
-      this.watermarkDom.setAttribute('style', getStyleStr(this.style));
+      applyStyle(this.watermarkDom, this.style);
     }
   }
 
   hide() {
     if (this.watermarkDom) {
       this.style['display'] = 'none';
-      this.watermarkDom.setAttribute('style', getStyleStr(this.style));
+      applyStyle(this.watermarkDom, this.style);
     }
   }
 
@@ -171,7 +171,7 @@ export class Watermark {
         this.style['height'] = isNaN(Number(height)) ? height : height + 'px';
       }
 
-      this.watermarkDom.setAttribute('style', getStyleStr(this.style));
+      applyStyle(this.watermarkDom, this.style);
     }
 
     this.watermarkDom.setAttribute(attributeNameTag, this.watermarkTag);


### PR DESCRIPTION
Replace `setAttribute('style', ...)` with `element.style.setProperty()` to eliminate the need for `style-src 'unsafe-inline'` in CSP policies.

Closes #2 